### PR TITLE
RELATED: RAIL-1985 prevent infinite loop in logout

### DIFF
--- a/bootstrap/src/components/Auth/LogoutForm.js
+++ b/bootstrap/src/components/Auth/LogoutForm.js
@@ -3,9 +3,13 @@ import { withRouter } from "react-router-dom";
 import CustomLoading from "../CustomLoading";
 
 const LogoutForm = ({ history, logout }) => {
-    useEffect(() => {
-        logout().then(() => history.push("/login"));
-    });
+    useEffect(
+        () => {
+            logout().then(() => history.push("/login"));
+        },
+        // only call the logout on initial mount -> the empty array is correct here
+        [], // eslint-disable-line react-hooks/exhaustive-deps
+    );
 
     return <CustomLoading label="Logging you out..." />;
 };


### PR DESCRIPTION
Logout function was called on every LogoutForm render.
LogoutForm was re-rendered due to setState calls
in auth context initiated by the logout function  -> infinite cycle.