### PR TITLE
RELATED: RAIL-2808 make sure the refresh-ldm script works on Windows

### DIFF
--- a/bootstrap/scripts/refresh-ldm.js
+++ b/bootstrap/scripts/refresh-ldm.js
@@ -3,4 +3,4 @@
 const { workspace, backend } = require("../src/constants");
 const path = "./src/ldm/full.js";
 process.argv.push("--project-id", workspace, "--hostname", backend, "--output", path);
-require("../node_modules/.bin/gdc-catalog-export");
+require("../node_modules/@gooddata/catalog-export");


### PR DESCRIPTION
There seems to be an issue on Windows with the .bin folder, for example jest hit it
https://github.com/facebook/jest/issues/4751#issuecomment-361063215

JIRA: RAIL-2808