### PR TITLE
RELATED: RAIL-3191 Use workspace-id instead of project-id for catalog export

### DIFF
--- a/bootstrap/scripts/refresh-ldm.js
+++ b/bootstrap/scripts/refresh-ldm.js
@@ -8,5 +8,5 @@ require("@babel/register")({
 
 const { workspace, backend } = require("../src/constants.ts");
 const path = "./src/ldm/full.ts";
-process.argv.push("--project-id", workspace, "--hostname", backend, "--output", path);
+process.argv.push("--workspace-id", workspace, "--hostname", backend, "--output", path);
 require("../node_modules/@gooddata/catalog-export");


### PR DESCRIPTION
This prevents unnecessary warnings.

Tested on both bear and tiger with current beta.

JIRA: RAIL-3191