### PR TITLE
RELATED: RAIL-3247 - Fix tiger file replacement on windows

### DIFF
--- a/src/processTigerFiles.js
+++ b/src/processTigerFiles.js
@@ -30,7 +30,10 @@ const processTigerFile = async (tigerVersion, isTigerBackend) => {
  * @param {boolean} isTigerBackend - flag indicating if the backend to use is tiger
  */
 const processTigerFiles = async (initialPath, isTigerBackend) => {
-    const pattern = path.posix.join(initialPath, "./**/*--tiger.*");
+    // The initial path on windows will contain backslash. Globby does not work with those and
+    // will find no tiger files on windows. Using normal slashes for globby and then node fs calls
+    // is no problem on windows.
+    const pattern = path.posix.join(initialPath, "./**/*--tiger.*").replace(/\\/g, "/");
     const tigerFiles = await globby(pattern);
 
     return Promise.all(tigerFiles.map(file => processTigerFile(file, isTigerBackend)));


### PR DESCRIPTION
-  Backslashes in path name break globby and it returns no --tiger files
   to use/delete

JIRA: RAIL-3247