### PR TITLE
RELATED: RAIL-3438 Fix refresh-md script in JavaScript apps

### DIFF
--- a/src/processJavaScriptFiles.js
+++ b/src/processJavaScriptFiles.js
@@ -92,11 +92,7 @@ const replacementDefinitions = {
         },
     },
     scripts: {
-        "refresh-ldm.js": [
-            {
-                regex: /constants\.ts/g,
-                value: "constants",
-            },
+        "refresh-md.js": [
             {
                 regex: /full\.ts/g,
                 value: "full.js",


### PR DESCRIPTION
Also remove obsolete replacement (both TS and JS versions
work without the extension).

JIRA: RAIL-3438