### PR TITLE
RELATED: RAIL-3955 Fix dashboard styles when not used inside of Page

### DIFF
--- a/bootstrap/src/components/Page.module.scss
+++ b/bootstrap/src/components/Page.module.scss
@@ -5,6 +5,13 @@
     flex-direction: column;
     align-items: stretch;
     min-height: 100vh;
+
+    :global {
+        .gd-dash-header-wrapper {
+            // offset the header so that the dashboard top bar is not hidden behind the application header when scrolling
+            top: $header-height !important;
+        }
+    }
 }
 
 .Main {

--- a/bootstrap/src/index.scss
+++ b/bootstrap/src/index.scss
@@ -34,8 +34,3 @@ h3 {
     margin-top: 2em;
     margin-bottom: 0.25em;
 }
-
-.gd-dash-header-wrapper {
-    // offset the header so that the dashboard top bar is not hidden behind it when scrolling
-    top: $header-height !important;
-}


### PR DESCRIPTION
Better scope the header style so that they are not applied
when the user removes the Page component.

JIRA: RAIL-3955