### PR TITLE
Drop support of the Internet Explorer 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ You can increase the logging level of `@gooddata/create-gooddata-react-app my-ap
 ```bash
 npx @gooddata/create-gooddata-react-app my-app --verbose
 ```
+
+#### Internet Explorer
+
+Internet Explorer 11 is [no longer supported](https://help.gooddata.com/pages/viewpage.action?pageId=86775029).

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -42,7 +42,10 @@
         "production": [
             ">0.2%",
             "not dead",
-            "not op_mini all"
+            "not ie 11",
+            "not chrome < 51",
+            "not safari < 10",
+            "not android < 51"
         ],
         "development": [
             "last 1 chrome version",

--- a/bootstrap/yarn.lock
+++ b/bootstrap/yarn.lock
@@ -4369,9 +4369,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001061, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001286:
-  version "1.0.30001292"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz#4a55f61c06abc9595965cfd77897dc7bc1cdc456"
-  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
+  version "1.0.30001355"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz"
+  integrity sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Otherwise, GeoCharts are not working in boilerplate due to some babel transforms
- See related MapBox issue: https://github.com/mapbox/mapbox-gl-js/issues/10565
- https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling

JIRA: RAIL-4312